### PR TITLE
Migrate to Stripe's Checkout API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 dist/
+*.pyc
+*.egg-info

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 indico-plugin-payment-stripe
 ============================
 
-**This fork uses Strip's checkout instead of the v2 API, allowing it to be SCA-complaint.**
+**This fork uses Stripe's checkout instead of the v2 API, allowing it to be SCA-complaint.**
 
 `Stripe <https://stripe.com/>`_ payment support plugin for the `Indico conference management system <https://getindico.io>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,14 @@
 indico-plugin-payment-stripe
 ============================
 
+**This fork uses Strip's checkout instead of the v2 API, allowing it to be SCA-complaint.**
+
 `Stripe <https://stripe.com/>`_ payment support plugin for the `Indico conference management system <https://getindico.io>`_.
 
 This plugin was tested and developed using:
 
-* Indico version 2.1.7
-* Stripe API version 2018-11-02.
+* Indico version 2.2.4
+* Stripe API version 2020-02-18.
 
 Other versions of Indico and/or Stripe may or may not function as intended. We recommend that you test your integration
 thoroughly before using this plugin.

--- a/indico_payment_stripe/blueprint.py
+++ b/indico_payment_stripe/blueprint.py
@@ -22,4 +22,4 @@ blueprint = IndicoPluginBlueprint(
     )
 )
 
-blueprint.add_url_rule('/handler', 'handler', RHStripe, methods=['POST'])
+blueprint.add_url_rule('/handler', 'handler', RHStripe, methods=['GET'])

--- a/indico_payment_stripe/controllers.py
+++ b/indico_payment_stripe/controllers.py
@@ -9,9 +9,8 @@
 from __future__ import unicode_literals
 
 import stripe
-from flask import flash, redirect, request, Markup
 from flask_pluginengine import current_plugin
-from stripe import error as err
+from flask import flash, redirect, request, Markup
 from werkzeug.exceptions import BadRequest
 
 from indico.modules.events.payment.models.transactions import TransactionAction
@@ -20,21 +19,11 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.web.flask.util import url_for
 from indico.web.rh import RH
 
-from .utils import _, conv_to_stripe_amount, conv_from_stripe_amount
-
+from .utils import _, conv_from_stripe_amount
 
 __all__ = ['RHStripe']
 
-
-STRIPE_TRX_ACTION_MAP = {
-    'succeeded': TransactionAction.complete,
-    'failed': TransactionAction.reject,
-    'pending': TransactionAction.pending
-}
-
-
 class RHStripe(RH):
-
     """Processes the responses sent by Stripe."""
 
     CSRF_ENABLED = False
@@ -47,134 +36,32 @@ class RHStripe(RH):
         )
 
     def _process_args(self):
-        # TODO: Validation?
-        # Stripe-specific form data.
-        self.stripe_token = request.form['stripeToken']
-        self.stripe_token_type = request.form['stripeTokenType']
-        self.stripe_email = request.form['stripeEmail']
-        # Indico-specific form data.
-        self.token = request.args['token']
-        self.registration = Registration.find_first(uuid=self.token)
+        registration_uuid = request.args['registration_uuid']
+        self.registration = Registration.find_first(uuid=registration_uuid)
         if not self.registration:
-            raise BadRequest
+            raise BadRequest("Registration UUID not provided in callback")
 
-    def _process(self):
-
-        description = self._get_event_settings('description')
         use_event_api_keys = self._get_event_settings('use_event_api_keys')
-        sec_key = (
+        stripe.api_key = (
             self._get_event_settings('sec_key')
             if use_event_api_keys else
             current_plugin.settings.get('sec_key')
         )
 
-        # Several redirect possibilities:
-        # To registration form:
-        #   1. Successful payment.
-        #   2. Possibly successful payment, manual review required.
-        reg_url = url_for(
-            'event_registration.display_regform',
-            self.registration.locator.registrant
+        self.session = stripe.checkout.Session.retrieve(
+            request.args['session_id']
         )
-        # To checkout page:
-        #   1. Fail.
-        chk_url = url_for(
-            'payment.event_payment',
-            self.registration.locator.registrant,
-        )
+        if not self.session:
+            raise BadRequest("Invalid stripe session")
 
-        try:
-            charge = stripe.Charge.create(
-                api_key=sec_key,
-                amount=conv_to_stripe_amount(
-                    self.registration.price,
-                    self.registration.currency
-                ),
-                currency=self.registration.currency.lower(),
-                # TODO: Use proper conference name.
-                description=description,
-                source=self.stripe_token,
-            )
+    def _process(self):
+        payment_intent_id = self.session.payment_intent
+        payment_intent = stripe.PaymentIntent.retrieve(payment_intent_id)
+        if len(payment_intent.charges.data) != 1:
+            raise BadRequest("Charges data doesn't contain only 1 item.")
+        charge = payment_intent.charges.data[0]
 
-        except err.APIConnectionError as e:
-            current_plugin.logger.exception(e)
-            flash(
-                _(
-                    'There was a problem connecting to Stripe.'
-                    ' Please try again.'
-                ),
-                'error'
-            )
-            return redirect(chk_url)
-
-        except err.CardError as e:
-            current_plugin.logger.exception(e)
-            flash(
-                _('Your payment was declined. Please try again.'),
-                'error'
-            )
-            return redirect(chk_url)
-
-        except Exception as e:
-            current_plugin.logger.exception(e)
-            flash(
-                _('Your payment can not be made. Please try again.'),
-                'error'
-            )
-            return redirect(chk_url)
-
-        outcome = charge['outcome']
-        outc_type = outcome['type']
-        seller_message = outcome.get('seller_message')
-        flash_msg = None
-        flash_type = None
-        receipt_url = None
-
-        # See: https://stripe.com/docs/declines
-        if outc_type == 'issuer_declined':
-            flash_msg = _('Your payment failed because your card was declined.')
-            flash_type = 'error'
-            current_plugin.logger.error(seller_message)
-            flash(flash_msg, flash_type)
-            return redirect(reg_url)
-
-        elif outc_type == 'blocked':
-            flash_msg = _(
-                'Your payment failed because it was classified as high risk.'
-            )
-            flash_type = 'error'
-            current_plugin.logger.error(seller_message)
-            flash(flash_msg, flash_type)
-            return redirect(reg_url)
-
-        elif outc_type == 'manual_review':
-            receipt_url = charge['receipt_url']
-            flash_msg = Markup(_(
-                'Your payment request has been processed and will be reviewed'
-                ' soon. See the receipt <a href="' + receipt_url + '">here</a>.'
-            ))
-            flash_type = 'info'
-
-        elif outc_type == 'authorized':
-            receipt_url = charge['receipt_url']
-            flash_msg = Markup(_(
-                'Your payment request has been processed.'
-                ' See the receipt <a href="' + receipt_url + '">here</a>.'
-            ))
-            flash_type = 'success'
-
-        else:
-            # This is actually the 'invalid' outcome type, which indicates
-            # our API call is wrong.
-            flash_msg = _(
-                'Payment failed because something went wrong on our end.'
-                ' Please notify the event contact person.'
-            )
-            flash_type = 'error'
-            flash(flash_msg, flash_type)
-            return redirect(reg_url)
-
-        transaction_data = request.form.to_dict()
+        transaction_data = {}
         transaction_data['charge_id'] = charge['id']
         register_transaction(
             registration=self.registration,
@@ -183,10 +70,19 @@ class RHStripe(RH):
                 charge['currency']
             ),
             currency=charge['currency'],
-            action=STRIPE_TRX_ACTION_MAP[charge['status']],
+            action=TransactionAction.complete,
             provider='stripe',
             data=transaction_data
         )
 
-        flash(flash_msg, flash_type)
+        receipt_url = charge['receipt_url']
+        flash_msg = Markup(_(
+            'Your payment request has been processed.'
+            ' See the receipt <a href="' + receipt_url + '">here</a>.'
+        ))
+        flash(flash_msg, 'success')
+        reg_url = url_for(
+            'event_registration.display_regform',
+            self.registration.locator.registrant
+        )
         return redirect(reg_url)

--- a/indico_payment_stripe/templates/event_payment_form.html
+++ b/indico_payment_stripe/templates/event_payment_form.html
@@ -19,13 +19,13 @@
       js.type = "text/javascript";
       js.src = "https://js.stripe.com/v3";
       js.onload = event => {
-        var checkoutButton = document.querySelector('#checkout-button');
-        checkoutButton.addEventListener('click', function () {
+        var checkoutButton = document.querySelector("#checkout-button");
+        checkoutButton.addEventListener("click", function() {
           var stripe = Stripe("{{ pub_key }}");
           console.log(stripe);
           stripe
             .redirectToCheckout({
-              sessionId: "{{stripe_session_id}}"
+              sessionId: "{{ stripe_session_id }}"
             })
             .then(function(result) {
               // If `redirectToCheckout` fails due to a browser or network

--- a/indico_payment_stripe/utils.py
+++ b/indico_payment_stripe/utils.py
@@ -60,9 +60,8 @@ def conv_to_stripe_amount(
 
     """
     return (
-        int(indico_amount)
-        if curr.upper() in zero_decimal_currs else
-        int(indico_amount * 100)
+        int(indico_amount) if curr.upper() in zero_decimal_currs
+        else int(indico_amount * 100)
     )
 
 


### PR DESCRIPTION
This moves the plugin to [Stripe's Checkout API](https://stripe.com/docs/payments/checkout), making it work with cards that require authentication.